### PR TITLE
Recognize and extract kube-prometheus-stack images provided via container args

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -32,12 +32,13 @@ builds:
 
 archives:
   - format: tar.gz
-    replacements:
-      darwin: Darwin
-      linux: Linux
-      386: i386
-      amd64: x86_64
-      name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+    name_template: >-
+      {{- .ProjectName }}_
+      {{- .Version }}_
+      {{- .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
     files:
       - plugin.yaml
       - LICENSE

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -46,7 +46,7 @@ archives:
       - install-binary.sh
 
 snapshot:
-  name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+  name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Runtime.Goos }}_{{ .Runtime.Goarch }}"
 
 checksum:
   name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ local.check: local.fmt ## Loads all the dependencies to vendor directory
 	@go mod tidy
 
 local.build: local.check ## Generates the artifact with the help of 'go build'
-	GOVERSION=${GOVERSION} BUILD_ENVIRONMENT=${BUILD_ENVIRONMENT} goreleaser build --rm-dist
+	GOVERSION=${GOVERSION} BUILD_ENVIRONMENT=${BUILD_ENVIRONMENT} goreleaser build --clean
 
 local.push: local.build ## Pushes built artifact to the specified location
 
@@ -42,10 +42,10 @@ local.run: local.build ## Generates the artifact and start the service in the cu
 	./${APP_NAME}
 
 publish: local.check ## Builds and publishes the app
-	GOVERSION=${GOVERSION} BUILD_ENVIRONMENT=${BUILD_ENVIRONMENT} PLUGIN_PATH=${APP_DIR} goreleaser release --rm-dist
+	GOVERSION=${GOVERSION} BUILD_ENVIRONMENT=${BUILD_ENVIRONMENT} PLUGIN_PATH=${APP_DIR} goreleaser release --clean
 
 mock.publish: local.check ## Builds and mocks app release
-	GOVERSION=${GOVERSION} BUILD_ENVIRONMENT=${BUILD_ENVIRONMENT} PLUGIN_PATH=${APP_DIR} goreleaser release --skip-publish --rm-dist
+	GOVERSION=${GOVERSION} BUILD_ENVIRONMENT=${BUILD_ENVIRONMENT} PLUGIN_PATH=${APP_DIR} goreleaser release --skip-publish --clean
 
 lint: ## Lint's application for errors, it is a linters aggregator (https://github.com/golangci/golangci-lint).
 	if [ -z "${DEV}" ]; then golangci-lint run --color always ; else docker run --rm -v $(APP_DIR):/app -w /app golangci/golangci-lint:v1.46.2-alpine golangci-lint run --color always ; fi

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,9 @@ local.check: local.fmt ## Loads all the dependencies to vendor directory
 local.build: local.check ## Generates the artifact with the help of 'go build'
 	GOVERSION=${GOVERSION} BUILD_ENVIRONMENT=${BUILD_ENVIRONMENT} goreleaser build --clean
 
+local.snapshot: local.check ## Generates the artifact with the help of 'go build'
+	GOVERSION=${GOVERSION} BUILD_ENVIRONMENT=${BUILD_ENVIRONMENT} goreleaser build --snapshot --clean
+
 local.push: local.build ## Pushes built artifact to the specified location
 
 local.run: local.build ## Generates the artifact and start the service in the current directory

--- a/pkg/from_template.go
+++ b/pkg/from_template.go
@@ -11,6 +11,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+var errHelmBinNotSet = errors.New("environment variable HELM_BIN is not set")
+
 // getChartFromTemplate should get the manifests by rendering the helm template.
 func (image *Images) getChartFromTemplate() ([]byte, error) {
 	flags := make([]string, 0)
@@ -60,7 +62,12 @@ func (image *Images) getChartFromTemplate() ([]byte, error) {
 
 	image.log.Debugf("rendering helm chart with following commands/flags '%s'", strings.Join(args, ", "))
 
-	cmd := exec.Command(os.Getenv("HELM_BIN"), args...) //nolint:gosec
+	helmBin := os.Getenv("HELM_BIN")
+	if helmBin == "" {
+		return nil, errHelmBinNotSet
+	}
+
+	cmd := exec.Command(helmBin, args...) //nolint:gosec
 	image.log.Debugf("running below command to render the helm template \n%s\n", cmd.String())
 	output, err := cmd.Output()
 


### PR DESCRIPTION
## Reason for PR

`helm-images` does not recognize the `prometheus-config-reloader` and `thanos` images provided via container arguments. This PR adds and additional check and append the additional images to the final output.

I've first tried to resolve this issue with the `kube-prometheus-stack` maintainers and they also opened an issue with `artifact.hub` but unfortunately it was closed. More about the discussion can be read [here](https://github.com/prometheus-community/helm-charts/issues/4161) and [here](https://github.com/artifacthub/hub/issues/3619).

### Other fixes

When I tried building the project with the `make local.build` command failed and after some investigation on how `goreleaser` works I've also implemented some build process fixes. Please see commits for details.

## Test procedure for container image extraction fix

Download `kube-prometheus-stack` and extract it (not the newest version, but this is the one I tested with)
```sh
$ curl -sLO https://github.com/prometheus-community/helm-charts/releases/download/kube-prometheus-stack-51.10.0/kube-prometheus-stack-51.10.0.tgz
$ tar xf kube-prometheus-stack-51.10.0.tgz
```

Extract images without fix
```sh
$ helm images get prometheus-community kube-prometheus-stack -f kube-prometheus-stack/values.yaml
quay.io/prometheus/node-exporter:v1.6.1
quay.io/kiwigrid/k8s-sidecar:1.25.1
quay.io/kiwigrid/k8s-sidecar:1.25.1
docker.io/grafana/grafana:10.1.5
registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.10.0
quay.io/prometheus-operator/prometheus-operator:v0.68.0
quay.io/prometheus/alertmanager:v0.26.0
quay.io/prometheus/prometheus:v2.47.1
docker.io/bats/bats:v1.4.1
registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20221220-controller-v1.5.1-58-g787ea74b6
registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20221220-controller-v1.5.1-58-g787ea74b6
```

Extract images with fix (I am using an ARM based Mac, so I chose the `darwin_arm64` binary)
```sh
$ export HELM_BIN=$(which helm)
$ make local.snapshot
$ ./dist/helm-images_darwin_arm64/helm-images get prometheus-community kube-prometheus-stack -f kube-prometheus-stack/values.yaml
quay.io/prometheus/node-exporter:v1.6.1
quay.io/kiwigrid/k8s-sidecar:1.25.1
quay.io/kiwigrid/k8s-sidecar:1.25.1
docker.io/grafana/grafana:10.1.5
registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.10.0
quay.io/prometheus-operator/prometheus-operator:v0.68.0
quay.io/prometheus-operator/prometheus-config-reloader:v0.68.0
quay.io/thanos/thanos:v0.32.4
quay.io/prometheus/alertmanager:v0.26.0
quay.io/prometheus/prometheus:v2.47.1
docker.io/bats/bats:v1.4.1
registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20221220-controller-v1.5.1-58-g787ea74b6
registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20221220-controller-v1.5.1-58-g787ea74b6
```

Observe these additional extracted images

- `quay.io/prometheus-operator/prometheus-config-reloader:v0.68.0`
- `quay.io/thanos/thanos:v0.32.4`