### PR TITLE
Replace template parsing with yaml.Decoder

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.8.4
 	github.com/thoas/go-funk v0.9.3
+	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v3 v3.14.2
 	k8s.io/api v0.29.0
 )
@@ -149,7 +150,6 @@ require (
 	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.29.0 // indirect
 	k8s.io/apimachinery v0.29.0 // indirect
 	k8s.io/apiserver v0.29.0 // indirect

--- a/pkg/images_all.go
+++ b/pkg/images_all.go
@@ -28,7 +28,11 @@ func (image *Images) GetAllImages() error {
 		image.log.Debugf("fetching the images from release '%s' of namespace '%s'", release.Name, release.Namespace)
 
 		images := make([]*k8s.Image, 0)
-		kubeKindTemplates := image.GetTemplates([]byte(release.Manifest))
+		kubeKindTemplates, err := image.GetTemplates([]byte(release.Manifest))
+		if err != nil {
+			return err
+		}
+
 		skips := image.GetResourcesToSkip()
 
 		for _, kubeKindTemplate := range kubeKindTemplates {

--- a/pkg/images_test.go
+++ b/pkg/images_test.go
@@ -60,8 +60,11 @@ roleRef:
  name: prometheus-standalone-kube-state-metrics
 subjects:
 - kind: ServiceAccount
- name: prometheus-standalone-kube-state-metrics
- namespace: test
+  name: prometheus-standalone-kube-state-metrics
+  namespace: test
+---
+# Empty template
+# Just comments
 ---
 # Source: tracing/templates/jaeger/configmap.yaml
 apiVersion: v1
@@ -71,30 +74,23 @@ metadata:
 data:
    CA_CERTIFICATE: |
        -----BEGIN CERTIFICATE-----
-		OCOIRRGVEGHEIGHEnwoircne20394809234nfh834retitneh83t5ljfKHD&$&$
-		OCOIRRGVEGHEIGHEnwoircne20394809234nfh834retitneh83t5ljfKHD&$&$
-		OCOIRRGVEGHEIGHEnwoircne20394809234nfh834retitneh83t5ljfKHD&$&$
-		OCOIRRGVEGHEIGHEnwoircne20394809234nfh834retitneh83t5ljfKHD&$&$
-		OCOIRRGVEGHEIGHEnwoircne20394809234nfh834retitneh83t5ljfKHD&$&$
-		OCOIRRGVEGHEIGHEnwoircne20394809234nfh834retitneh83t5ljfKHD&$&$
-		OCOIRRGVEGHEIGHEnwoircne20394809234nfh834retitneh83t5ljfKHD&$&$
-		OCOIRRGVEGHEIGHEnwoircne20394809234nfh834retitneh83t5ljfKHD&$&$
-		OCOIRRGVEGHEIGHEnwoircne20394809234nfh834retitneh83t5ljfKHD&$&$
-		OCOIRRGVEGHEIGHEnwoircne20394809234nfh834retitneh83t5ljfKHD&$&$
+       OCOIRRGVEGHEIGHEnwoircne20394809234nfh834retitneh83t5ljfKHD&$&$
+       OCOIRRGVEGHEIGHEnwoircne20394809234nfh834retitneh83t5ljfKHD&$&$
+       OCOIRRGVEGHEIGHEnwoircne20394809234nfh834retitneh83t5ljfKHD&$&$
+       OCOIRRGVEGHEIGHEnwoircne20394809234nfh834retitneh83t5ljfKHD&$&$
+       OCOIRRGVEGHEIGHEnwoircne20394809234nfh834retitneh83t5ljfKHD&$&$
+       OCOIRRGVEGHEIGHEnwoircne20394809234nfh834retitneh83t5ljfKHD&$&$
+       OCOIRRGVEGHEIGHEnwoircne20394809234nfh834retitneh83t5ljfKHD&$&$
+       OCOIRRGVEGHEIGHEnwoircne20394809234nfh834retitneh83t5ljfKHD&$&$
+       OCOIRRGVEGHEIGHEnwoircne20394809234nfh834retitneh83t5ljfKHD&$&$
+       OCOIRRGVEGHEIGHEnwoircne20394809234nfh834retitneh83t5ljfKHD&$&$
        -----END CERTIFICATE-----
 `
 
 	t.Run("should be able to split rendered templates to individual templates", func(t *testing.T) {
-		expected := []string{
-			"\napiVersion: rbac.authorization.k8s.io/v1\nkind: ClusterRole\nmetadata:\n labels:\n   component: \"alertmanager\"\n   app: prometheus\n   release: prometheus-standalone\n   chart: prometheus-14.4.1\n   heritage: Helm\n name: prometheus-standalone-alertmanager\nrules:\n []\n",                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        //nolint:lll
-			"\napiVersion: rbac.authorization.k8s.io/v1\nkind: ClusterRole\nmetadata:\n labels:\n   component: \"pushgateway\"\n   app: prometheus\n   release: prometheus-standalone\n   chart: prometheus-14.4.1\n   heritage: Helm\n name: prometheus-standalone-pushgateway\nrules:\n []\n",                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          //nolint:lll
-			"\napiVersion: rbac.authorization.k8s.io/v1\nkind: ClusterRoleBinding\nmetadata:\n labels:\n   app.kubernetes.io/name: kube-state-metrics\n   helm.sh/chart: kube-state-metrics-3.1.1\n   app.kubernetes.io/managed-by: Helm\n   app.kubernetes.io/instance: prometheus-standalone\n name: prometheus-standalone-kube-state-metrics\nroleRef:\n apiGroup: rbac.authorization.k8s.io\n kind: ClusterRole\n name: prometheus-standalone-kube-state-metrics\nsubjects:\n- kind: ServiceAccount\n name: prometheus-standalone-kube-state-metrics\n namespace: test\n",                                                                                                                                                                                                                                                                                                                            //nolint:lll
-			"\napiVersion: v1\nkind: ConfigMap\nmetadata:\n name: jaeger-ca-cert\ndata:\n   CA_CERTIFICATE: |\n       -----BEGIN CERTIFICATE-----\n\t\tOCOIRRGVEGHEIGHEnwoircne20394809234nfh834retitneh83t5ljfKHD&$&$\n\t\tOCOIRRGVEGHEIGHEnwoircne20394809234nfh834retitneh83t5ljfKHD&$&$\n\t\tOCOIRRGVEGHEIGHEnwoircne20394809234nfh834retitneh83t5ljfKHD&$&$\n\t\tOCOIRRGVEGHEIGHEnwoircne20394809234nfh834retitneh83t5ljfKHD&$&$\n\t\tOCOIRRGVEGHEIGHEnwoircne20394809234nfh834retitneh83t5ljfKHD&$&$\n\t\tOCOIRRGVEGHEIGHEnwoircne20394809234nfh834retitneh83t5ljfKHD&$&$\n\t\tOCOIRRGVEGHEIGHEnwoircne20394809234nfh834retitneh83t5ljfKHD&$&$\n\t\tOCOIRRGVEGHEIGHEnwoircne20394809234nfh834retitneh83t5ljfKHD&$&$\n\t\tOCOIRRGVEGHEIGHEnwoircne20394809234nfh834retitneh83t5ljfKHD&$&$\n\t\tOCOIRRGVEGHEIGHEnwoircne20394809234nfh834retitneh83t5ljfKHD&$&$\n       -----END CERTIFICATE-----\n", //nolint:lll
-		}
-		actual := imageClient.GetTemplates([]byte(helmTemplate))
-		assert.Equal(t, len(expected), len(actual))
-		// assert.Equal(t, sort.StringSlice(expected), sort.StringSlice(actual))
-		assert.ElementsMatch(t, expected, actual)
+		actual, err := imageClient.GetTemplates([]byte(helmTemplate))
+		assert.NoError(t, err)
+		assert.Len(t, actual, 4)
 	})
 }
 

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -65,12 +65,12 @@ type (
 
 // KindInterface implements method that identifies the type of kubernetes workloads.
 type KindInterface interface {
-	Get(dataMap string, log *logrus.Logger) (string, error)
+	Get(dataMap map[string]interface{}, log *logrus.Logger) (string, error)
 }
 
 // ImagesInterface implements method that gets images from various kubernetes workloads.
 type ImagesInterface interface {
-	Get(dataMap string, imageRegex string, log *logrus.Logger) (*Image, error)
+	Get(dataMap map[string]interface{}, imageRegex string, log *logrus.Logger) (*Image, error)
 }
 
 // Image holds information of images retrieved.
@@ -85,11 +85,7 @@ type Images struct {
 	NameSpace         string      `json:"name_space,omitempty"          yaml:"name_space,omitempty"`
 }
 
-func (name *Name) Get(dataMap string, log *logrus.Logger) (string, error) {
-	if err := yaml.Unmarshal([]byte(dataMap), name); err != nil {
-		return "", err
-	}
-
+func (name *Name) Get(dataMap map[string]interface{}, log *logrus.Logger) (string, error) {
 	kindYaml := *name
 
 	metadata, metadataExists := kindYaml["metadata"].(map[string]interface{})
@@ -107,11 +103,7 @@ func (name *Name) Get(dataMap string, log *logrus.Logger) (string, error) {
 	return metadataName, nil
 }
 
-func (kin *Kind) Get(dataMap string, log *logrus.Logger) (string, error) {
-	if err := yaml.Unmarshal([]byte(dataMap), &kin); err != nil {
-		return "", err
-	}
-
+func (kin *Kind) Get(dataMap map[string]interface{}, log *logrus.Logger) (string, error) {
 	if kin == nil {
 		log.Warn("looks like it manifest is empty")
 
@@ -130,11 +122,7 @@ func (kin *Kind) Get(dataMap string, log *logrus.Logger) (string, error) {
 }
 
 // Get identifies images from Deployments.
-func (dep *Deployments) Get(dataMap string, _ string, _ *logrus.Logger) (*Image, error) {
-	if err := yaml.Unmarshal([]byte(dataMap), &dep); err != nil {
-		return nil, err
-	}
-
+func (dep *Deployments) Get(dataMap map[string]interface{}, _ string, _ *logrus.Logger) (*Image, error) {
 	depContainers := containers{append(dep.Spec.Template.Spec.Containers, dep.Spec.Template.Spec.InitContainers...)}
 
 	images := &Image{
@@ -149,11 +137,7 @@ func (dep *Deployments) Get(dataMap string, _ string, _ *logrus.Logger) (*Image,
 }
 
 // Get identifies images from StatefulSets.
-func (dep *StatefulSets) Get(dataMap string, _ string, _ *logrus.Logger) (*Image, error) {
-	if err := yaml.Unmarshal([]byte(dataMap), &dep); err != nil {
-		return nil, err
-	}
-
+func (dep *StatefulSets) Get(dataMap map[string]interface{}, _ string, _ *logrus.Logger) (*Image, error) {
 	depContainers := containers{append(dep.Spec.Template.Spec.Containers, dep.Spec.Template.Spec.InitContainers...)}
 
 	images := &Image{
@@ -168,11 +152,7 @@ func (dep *StatefulSets) Get(dataMap string, _ string, _ *logrus.Logger) (*Image
 }
 
 // Get identifies images from DaemonSets.
-func (dep *DaemonSets) Get(dataMap string, _ string, _ *logrus.Logger) (*Image, error) {
-	if err := yaml.Unmarshal([]byte(dataMap), &dep); err != nil {
-		return nil, err
-	}
-
+func (dep *DaemonSets) Get(dataMap map[string]interface{}, _ string, _ *logrus.Logger) (*Image, error) {
 	depContainers := containers{append(dep.Spec.Template.Spec.Containers, dep.Spec.Template.Spec.InitContainers...)}
 
 	images := &Image{
@@ -187,11 +167,7 @@ func (dep *DaemonSets) Get(dataMap string, _ string, _ *logrus.Logger) (*Image, 
 }
 
 // Get identifies images from CronJob.
-func (dep *CronJob) Get(dataMap string, _ string, _ *logrus.Logger) (*Image, error) {
-	if err := yaml.Unmarshal([]byte(dataMap), &dep); err != nil {
-		return nil, err
-	}
-
+func (dep *CronJob) Get(dataMap map[string]interface{}, _ string, _ *logrus.Logger) (*Image, error) {
 	depContainers := containers{append(dep.Spec.JobTemplate.Spec.Template.Spec.Containers,
 		dep.Spec.JobTemplate.Spec.Template.Spec.InitContainers...)}
 
@@ -207,11 +183,7 @@ func (dep *CronJob) Get(dataMap string, _ string, _ *logrus.Logger) (*Image, err
 }
 
 // Get identifies images from Job.
-func (dep *Job) Get(dataMap string, _ string, _ *logrus.Logger) (*Image, error) {
-	if err := yaml.Unmarshal([]byte(dataMap), &dep); err != nil {
-		return nil, err
-	}
-
+func (dep *Job) Get(dataMap map[string]interface{}, _ string, _ *logrus.Logger) (*Image, error) {
 	depContainers := containers{append(dep.Spec.Template.Spec.Containers, dep.Spec.Template.Spec.InitContainers...)}
 
 	images := &Image{
@@ -226,11 +198,7 @@ func (dep *Job) Get(dataMap string, _ string, _ *logrus.Logger) (*Image, error) 
 }
 
 // Get identifies images from ReplicaSets.
-func (dep *ReplicaSets) Get(dataMap string, _ string, _ *logrus.Logger) (*Image, error) {
-	if err := yaml.Unmarshal([]byte(dataMap), &dep); err != nil {
-		return nil, err
-	}
-
+func (dep *ReplicaSets) Get(dataMap map[string]interface{}, _ string, _ *logrus.Logger) (*Image, error) {
 	depContainers := containers{append(dep.Spec.Template.Spec.Containers, dep.Spec.Template.Spec.InitContainers...)}
 
 	images := &Image{
@@ -245,11 +213,7 @@ func (dep *ReplicaSets) Get(dataMap string, _ string, _ *logrus.Logger) (*Image,
 }
 
 // Get identifies images from Pod.
-func (dep *Pod) Get(dataMap string, _ string, _ *logrus.Logger) (*Image, error) {
-	if err := yaml.Unmarshal([]byte(dataMap), &dep); err != nil {
-		return nil, err
-	}
-
+func (dep *Pod) Get(dataMap map[string]interface{}, _ string, _ *logrus.Logger) (*Image, error) {
 	depContainers := containers{append(dep.Spec.Containers, dep.Spec.InitContainers...)}
 
 	images := &Image{
@@ -264,11 +228,7 @@ func (dep *Pod) Get(dataMap string, _ string, _ *logrus.Logger) (*Image, error) 
 }
 
 // Get identifies images from AlertManager.
-func (dep *AlertManager) Get(dataMap string, _ string, _ *logrus.Logger) (*Image, error) {
-	if err := yaml.Unmarshal([]byte(dataMap), &dep); err != nil {
-		return nil, err
-	}
-
+func (dep *AlertManager) Get(dataMap map[string]interface{}, _ string, _ *logrus.Logger) (*Image, error) {
 	images := &Image{
 		Kind:  monitoringV1.AlertmanagersKind,
 		Name:  dep.Name,
@@ -279,11 +239,7 @@ func (dep *AlertManager) Get(dataMap string, _ string, _ *logrus.Logger) (*Image
 }
 
 // Get identifies images from Prometheus.
-func (dep *Prometheus) Get(dataMap string, _ string, _ *logrus.Logger) (*Image, error) {
-	if err := yaml.Unmarshal([]byte(dataMap), &dep); err != nil {
-		return nil, err
-	}
-
+func (dep *Prometheus) Get(dataMap map[string]interface{}, _ string, _ *logrus.Logger) (*Image, error) {
 	var imageNames []string
 
 	depContainers := containers{append(dep.Spec.Containers, dep.Spec.InitContainers...)}
@@ -301,11 +257,7 @@ func (dep *Prometheus) Get(dataMap string, _ string, _ *logrus.Logger) (*Image, 
 }
 
 // Get identifies images from ThanosRuler.
-func (dep *ThanosRuler) Get(dataMap string, _ string, _ *logrus.Logger) (*Image, error) {
-	if err := yaml.Unmarshal([]byte(dataMap), &dep); err != nil {
-		return nil, err
-	}
-
+func (dep *ThanosRuler) Get(dataMap map[string]interface{}, _ string, _ *logrus.Logger) (*Image, error) {
 	var imageNames []string
 
 	depContainers := containers{append(dep.Spec.Containers, dep.Spec.InitContainers...)}
@@ -323,11 +275,7 @@ func (dep *ThanosRuler) Get(dataMap string, _ string, _ *logrus.Logger) (*Image,
 }
 
 // Get identifies images from Grafana.
-func (dep *Grafana) Get(dataMap string, _ string, _ *logrus.Logger) (*Image, error) {
-	if err := yaml.Unmarshal([]byte(dataMap), &dep); err != nil {
-		return nil, err
-	}
-
+func (dep *Grafana) Get(dataMap map[string]interface{}, _ string, _ *logrus.Logger) (*Image, error) {
 	if dep.APIVersion == "integreatly.org/v1alpha1" {
 		return nil, &imgErrors.GrafanaAPIVersionSupportError{
 			Message: fmt.Sprintf("plugin supports the latest api version and '%s' is not supported", dep.APIVersion),
@@ -347,11 +295,7 @@ func (dep *Grafana) Get(dataMap string, _ string, _ *logrus.Logger) (*Image, err
 }
 
 // Get identifies images from Thanos.
-func (dep *Thanos) Get(dataMap string, _ string, _ *logrus.Logger) (*Image, error) {
-	if err := yaml.Unmarshal([]byte(dataMap), &dep); err != nil {
-		return nil, err
-	}
-
+func (dep *Thanos) Get(dataMap map[string]interface{}, _ string, _ *logrus.Logger) (*Image, error) {
 	thanosContainers := make([]coreV1.Container, 0)
 	thanosContainers = append(thanosContainers, dep.Spec.Rule.StatefulsetOverrides.Spec.Template.Spec.Containers...)
 	thanosContainers = append(thanosContainers, dep.Spec.Rule.StatefulsetOverrides.Spec.Template.Spec.InitContainers...)
@@ -374,11 +318,7 @@ func (dep *Thanos) Get(dataMap string, _ string, _ *logrus.Logger) (*Image, erro
 }
 
 // Get identifies images from ThanosReceiver.
-func (dep *ThanosReceiver) Get(dataMap string, _ string, _ *logrus.Logger) (*Image, error) {
-	if err := yaml.Unmarshal([]byte(dataMap), &dep); err != nil {
-		return nil, err
-	}
-
+func (dep *ThanosReceiver) Get(dataMap map[string]interface{}, _ string, _ *logrus.Logger) (*Image, error) {
 	receiverGroupTotalContainers := make([]coreV1.Container, 0)
 
 	for _, receiverGroup := range dep.Spec.ReceiverGroups {
@@ -398,11 +338,7 @@ func (dep *ThanosReceiver) Get(dataMap string, _ string, _ *logrus.Logger) (*Ima
 	return images, nil
 }
 
-func (dep *ConfigMap) Get(dataMap string, imageRegex string, log *logrus.Logger) (*Image, error) {
-	if err := yaml.Unmarshal([]byte(dataMap), &dep); err != nil {
-		return nil, err
-	}
-
+func (dep *ConfigMap) Get(dataMap map[string]interface{}, imageRegex string, log *logrus.Logger) (*Image, error) {
 	images := &Image{
 		Kind:  KindConfigMap,
 		Name:  dep.Name,

--- a/pkg/k8s/k8s_test.go
+++ b/pkg/k8s/k8s_test.go
@@ -5,7 +5,9 @@ import (
 	"testing"
 
 	"github.com/ghodss/yaml"
+	"github.com/nikhilsbhat/helm-images/pkg"
 	"github.com/nikhilsbhat/helm-images/pkg/k8s"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -35,7 +37,7 @@ config:
 		err := yaml.Unmarshal([]byte(yamlData), &valueMap)
 		require.NoError(t, err)
 
-		valueFound, _ := k8s.GetImage(valueMap, "image", "", nil)
+		valueFound, _ := k8s.GetImage(valueMap, "image", pkg.ConfigMapImageRegex, logrus.StandardLogger())
 		assert.ElementsMatch(t, []string{
 			"ghcr.io/example/config:v2.3.0",
 			"ghcr.io/example/testConfig:v2.3.0",
@@ -49,9 +51,8 @@ config:
 		err := json.Unmarshal([]byte(jsonData), &valueMap)
 		require.NoError(t, err)
 
-		valueFound, _ := k8s.GetImage(valueMap, "image", "", nil)
+		valueFound, _ := k8s.GetImage(valueMap, "image", pkg.ConfigMapImageRegex, logrus.StandardLogger())
 		assert.ElementsMatch(t, []string{
-			"ghcr.io/prometheus/prom:v2.0.0",
 			"ghcr.io/example/sample:v2.2.0",
 			"ghcr.io/example/config:v2.3.0",
 		}, valueFound)


### PR DESCRIPTION
This solves some of the edge cases around parsing for empty or invalid document by replacing the string splitting with the yaml package's native handling of multi-document files. Along the way it also simplifies upstream functions by returning parsed yaml as a map[string]interface{} instead of a string. Even after #29 I still had issues with documents like:

```
---
# <snip, normal document>
          env:
            - name: "GOMAXPROCS"
              value: "5"
            - name: "GOMEMLIMIT"
              value: "6442450944"
            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
              value: "1000"
---
# Source: mimir/charts/mimir-distributed/templates/minio/create-bucket-job.yaml
# Minio provides post-install hook to create bucket
# however the hook won't be executed if helm install is run
# with --wait flag. Hence this job is a workaround for that.
# See https://github.com/grafana/mimir/issues/2464
---
# Source: mimir/charts/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
apiVersion: monitoring.coreos.com/v1
kind: PrometheusRule
metadata:
  name: mimir-alerts
# <etc>
```

In the event of an un-parseable document you'll receive an error with the parsing error and the document the parsing failed on. This isn't _extremely_ useful and returning the chunk around the failure seems like it'd be more useful, but that's beyond my skills and this should point folks in the right direction at least.

One other note is I had to fix a test error that currently exists in master (see 7d26eaf) with the image-regex functionality. Along the way I spent a little time digging in and I'm pretty sure that it doesn't work at all since none of the `Get` calls ([see Deployments](https://github.com/nikhilsbhat/helm-images/blob/master/pkg/images.go#L237)) are passing through the regex except ConfigMap. I have a partial branch that attempts to make image-regex work but didn't want to block this fix with that.